### PR TITLE
SCSS & JS Lint

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,4 @@
+*.png
+*.html
+*.scss
+lib/

--- a/.sass-lint.yml
+++ b/.sass-lint.yml
@@ -18,7 +18,7 @@ rules:
 
   # Disallows
   no-color-keywords: 1
-  no-color-literals: 1
+  no-color-literals: 0
   no-css-comments: 1
   no-debug: 1
   no-duplicate-properties: 1
@@ -48,7 +48,10 @@ rules:
   id-name-format: 1
   mixin-name-format: 1
   placeholder-name-format: 1
-  variable-name-format: 1
+  variable-name-format:
+    - 1
+    -
+      convention: camelcase
 
   # Style Guide
   bem-depth: 1
@@ -61,10 +64,7 @@ rules:
   indentation: 1
   leading-zero: 1
   nesting-depth: 1
-  property-sort-order:
-    - 1
-    -
-      order: concentric
+  property-sort-order: 0
   quotes: 1
   shorthand-values: 1
   url-quotes: 1

--- a/examples/style.scss
+++ b/examples/style.scss
@@ -10,11 +10,10 @@ h5 { font-size: .8em; }
 
 section {
   $baseColor: #e4d234;
-
-  padding: 25px;
-  box-shadow: 0 0 6px rgba(0,0,0,.6);
-  border-radius: 6px;
   margin-bottom: 25px;
-  background-color: lighten($baseColor, 5%);
+  padding: 25px;
   border: 1px solid darken($baseColor, 10%);
+  border-radius: 6px;
+  background-color: lighten($baseColor, 5%);
+  box-shadow: 0 0 6px rgba(0, 0, 0, .6);
 }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
   ],
   "scripts": {
     "clean": "rimraf lib",
-    "lint": "eslint src && eslint docs && eslint examples && sass-lint --verbose",
+    "lint": "npm run lint-scripts && npm run lint-styles",
+    "lint-scripts": "eslint src/** examples/** --ext .js",
+    "lint-styles": "sass-lint --config .sass-lint.yml --verbose --no-exit",
     "build": "npm run clean && babel --quiet src/components --out-dir lib && cpy \"**/*.scss\" ../../lib/ --parents --cwd=src/components && node scripts/compile.js",
     "demo": "npm run build && node server.js examples/webpack.config.js",
     "release-patch": "npm run build && npm version patch",
@@ -59,6 +61,7 @@
     "postcss-loader": "^1.2.0",
     "release-it": "^2.5.1",
     "rimraf": "^2.5.4",
+    "sass-lint": "^1.10.2",
     "sass-loader": "^4.0.2",
     "style-loader": "^0.13.1",
     "through2": "^2.0.3",


### PR DESCRIPTION
# Add a SCSS and JS linter to the workflow

## Resources
- https://github.com/sasstools/sass-lint
- https://github.com/brigade/scss-lint
- http://blog.sass-lang.com/posts/1022316-announcing-dart-sass
- http://stylelint.io/

## Installation

```
$ npm i -D sass-lint
```

## Lint Commands

### Lint both `.js` and `.scss` files

```js
npm run lint
```

### Lint only `.js` files

```js
npm run lint-scripts
```

### Lint only `.scss` files

```js
npm run lint-styles
```

## Issues Fixed

- Add linter tool to flag problems on scss and js files #4 